### PR TITLE
PER_5831: Update dependencies and selenium test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,24 +4,24 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.6
+          ruby-version: 3.4
           bundler-cache: true
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: "./vendor/bundle"
-          key: v1/${{ runner.os }}/ruby-2.6/${{ hashFiles('**/Gemfile.lock') }}
-          restore-keys: v1/${{ runner.os }}/ruby-2.6/
-      - uses: actions/setup-node@v1
+          key: v1/${{ runner.os }}/ruby-3.4/${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: v1/${{ runner.os }}/ruby-3.4/
+      - uses: actions/setup-node@v4
         with:
-          node-version: 18
-      - uses: actions/cache@v3
+          node-version: 20
+      - uses: actions/cache@v4
         with:
           path: ~/.npm
-          key: v1/${{ runner.os }}/node-18/${{ hashFiles('**/package-lock.lock') }}
-          restore-keys: v1/${{ runner.os }}/node-18/
+          key: v1/${{ runner.os }}/node-20/${{ hashFiles('**/package-lock.json') }}
+          restore-keys: v1/${{ runner.os }}/node-20/
       - run: make test
         env:
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}

--- a/Gemfile
+++ b/Gemfile
@@ -5,5 +5,7 @@ source "https://rubygems.org"
 git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
 # gem "rails"
-gem 'selenium-webdriver', '~> 4.0.0.beta3'
+gem 'selenium-webdriver', '~> 4.36.0'
 gem 'percy-selenium', '~> 1.1.1'
+gem 'webrick'
+gem 'base64'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,24 +1,34 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    childprocess (4.0.0)
+    base64 (0.3.0)
+    json (2.13.2)
+    logger (1.7.0)
     percy-selenium (1.1.1)
       selenium-webdriver (>= 4.0.0.beta1)
-    rexml (3.2.5)
-    rubyzip (2.3.0)
-    selenium-webdriver (4.0.0.beta3)
-      childprocess (>= 0.5, < 5.0)
-      rexml (~> 3.2)
-      rubyzip (>= 1.2.2)
+    prism (1.4.0)
+    rexml (3.4.4)
+    rubyzip (3.1.1)
+    selenium-webdriver (4.36.0)
+      base64 (~> 0.2)
+      json (<= 2.13.2)
+      logger (~> 1.4)
+      prism (~> 1.0, < 1.5)
+      rexml (~> 3.2, >= 3.2.5)
+      rubyzip (>= 1.2.2, < 4.0)
       websocket (~> 1.0)
-    websocket (1.2.9)
+    webrick (1.9.1)
+    websocket (1.2.11)
 
 PLATFORMS
+  arm64-darwin-24
   ruby
 
 DEPENDENCIES
+  base64
   percy-selenium (~> 1.1.1)
-  selenium-webdriver (~> 4.0.0.beta3)
+  selenium-webdriver (~> 4.36.0)
+  webrick
 
 BUNDLED WITH
-   1.17.2
+   2.7.1

--- a/README.md
+++ b/README.md
@@ -5,6 +5,13 @@
 Example app showing integration of [Percy](https://percy.io/) visual testing
 into Ruby Selenium tests.
 
+## Versions used in this branch
+
+- selenium-webdriver: 4.36.0
+- percy-selenium: 1.1.1
+- @percy/cli: 1.31.2
+- todomvc-app-css: 2.4.3
+
 Based on the [TodoMVC](https://github.com/tastejs/todomvc) [VanillaJS](https://github.com/tastejs/todomvc/tree/master/examples/vanillajs)
 app, forked at commit [4e301c7014093505dcf6678c8f97a5e8dee2d250](https://github.com/tastejs/todomvc/tree/4e301c7014093505dcf6678c8f97a5e8dee2d250).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,10 +5,10 @@
   "packages": {
     "": {
       "dependencies": {
-        "todomvc-app-css": "^2.3.0"
+        "todomvc-app-css": "^2.4.3"
       },
       "devDependencies": {
-        "@percy/cli": "^1.30.11"
+        "@percy/cli": "^1.31.2"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -75,21 +75,21 @@
       }
     },
     "node_modules/@percy/cli": {
-      "version": "1.30.11",
-      "resolved": "https://registry.npmjs.org/@percy/cli/-/cli-1.30.11.tgz",
-      "integrity": "sha512-+UX5w5m3CT7g6OrcYL6WTOTL81dYOG14RxgAuvu8i+6ua2smSN2VfMF8ibHsD+BE/CkHXyqymvosyedWcsVZJw==",
+      "version": "1.31.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli/-/cli-1.31.2.tgz",
+      "integrity": "sha512-/jwlEMuVw0+9fkhUqc8m7s6WU8iZDeOffqVsg0Z2pfznFPvtH3IZtCWqqQan9JjQnx3UbidQPDb50UJ8Xn/AuQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@percy/cli-app": "1.30.11",
-        "@percy/cli-build": "1.30.11",
-        "@percy/cli-command": "1.30.11",
-        "@percy/cli-config": "1.30.11",
-        "@percy/cli-exec": "1.30.11",
-        "@percy/cli-snapshot": "1.30.11",
-        "@percy/cli-upload": "1.30.11",
-        "@percy/client": "1.30.11",
-        "@percy/logger": "1.30.11"
+        "@percy/cli-app": "1.31.2",
+        "@percy/cli-build": "1.31.2",
+        "@percy/cli-command": "1.31.2",
+        "@percy/cli-config": "1.31.2",
+        "@percy/cli-exec": "1.31.2",
+        "@percy/cli-snapshot": "1.31.2",
+        "@percy/cli-upload": "1.31.2",
+        "@percy/client": "1.31.2",
+        "@percy/logger": "1.31.2"
       },
       "bin": {
         "percy": "bin/run.cjs"
@@ -99,42 +99,42 @@
       }
     },
     "node_modules/@percy/cli-app": {
-      "version": "1.30.11",
-      "resolved": "https://registry.npmjs.org/@percy/cli-app/-/cli-app-1.30.11.tgz",
-      "integrity": "sha512-Iq3QGaDsKWEKIIRQzq09OxuwSFhV2JtGT9poZ9RvDaFrKcy3e3VkHWNH/jcxSv0IPNB6EptEfoG8XVY93OKA8Q==",
+      "version": "1.31.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli-app/-/cli-app-1.31.2.tgz",
+      "integrity": "sha512-juAi7R1ulaMtVLlG//duiEFPo/Aj60ePtEGXCqK5BWboXxJ2Sf6qkfvGo5Tb/GfHziHK7+MQ6GK5yRNaL21k8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@percy/cli-command": "1.30.11",
-        "@percy/cli-exec": "1.30.11"
+        "@percy/cli-command": "1.31.2",
+        "@percy/cli-exec": "1.31.2"
       },
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@percy/cli-build": {
-      "version": "1.30.11",
-      "resolved": "https://registry.npmjs.org/@percy/cli-build/-/cli-build-1.30.11.tgz",
-      "integrity": "sha512-o0qyiW+F3xX+X/pnKgSgK4Dvc1PKqWHvceanWOw0t1F8Qdq5n/rYOHwkpYKV+jOE4vEH1tpdcRo8YsXq9C+0ug==",
+      "version": "1.31.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli-build/-/cli-build-1.31.2.tgz",
+      "integrity": "sha512-/sRVbIhHaoZWcSAd3ZV31EpJ2A/xBSSmKMoj+aHxKhB+KcSgs8622RdKk4SBzQj/GdOIZjoDxD2XsMtnDgbBuA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@percy/cli-command": "1.30.11"
+        "@percy/cli-command": "1.31.2"
       },
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@percy/cli-command": {
-      "version": "1.30.11",
-      "resolved": "https://registry.npmjs.org/@percy/cli-command/-/cli-command-1.30.11.tgz",
-      "integrity": "sha512-UIkk3IGI5Tazhy6Kho+M04oG9ZFfpyqDuCFGHYNm5ZUPgZcGK0BUrEd9/JmjLPA9AIMSlFn2PGzWSzNDT1+ThQ==",
+      "version": "1.31.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli-command/-/cli-command-1.31.2.tgz",
+      "integrity": "sha512-9baEK7VDU02WUQKcH7M/hohiDlIH7DUEC1kdk7MED+z5hnKWO9DkgcbMpmNbGUTiKb+uPY7nt6h8nNI9kWJMxw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@percy/config": "1.30.11",
-        "@percy/core": "1.30.11",
-        "@percy/logger": "1.30.11"
+        "@percy/config": "1.31.2",
+        "@percy/core": "1.31.2",
+        "@percy/logger": "1.31.2"
       },
       "bin": {
         "percy-cli-readme": "bin/readme.js"
@@ -144,27 +144,27 @@
       }
     },
     "node_modules/@percy/cli-config": {
-      "version": "1.30.11",
-      "resolved": "https://registry.npmjs.org/@percy/cli-config/-/cli-config-1.30.11.tgz",
-      "integrity": "sha512-R42o/XI1x44vUe4BYlpNrKioc+8PxrC554GcnKmgSWENRnT8e1dZKl3jb5ppKd0qUPBnqDEJCGvpzAVVeiTNuQ==",
+      "version": "1.31.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli-config/-/cli-config-1.31.2.tgz",
+      "integrity": "sha512-9yCOj6LtPd9/E4y9SkhM9IWUdkr2uIchVNXTlTPZizQkuyT2gyolN0y0dddrR4TpmG/K+pLXOQDqRRNTpdY0gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@percy/cli-command": "1.30.11"
+        "@percy/cli-command": "1.31.2"
       },
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@percy/cli-exec": {
-      "version": "1.30.11",
-      "resolved": "https://registry.npmjs.org/@percy/cli-exec/-/cli-exec-1.30.11.tgz",
-      "integrity": "sha512-UqRx7NaGTtuWhr/Ucq4PCKnJ5V6dTgi5hDZdSWwBhpqHmhdKGD3JFZVCC9xXAO84M7n6VbWOnIDpv+AVe/XWeg==",
+      "version": "1.31.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli-exec/-/cli-exec-1.31.2.tgz",
+      "integrity": "sha512-IuO/+kFLSKJmPG3R66V4Lp5V4f7O/6wjnWc4X/71OFcywVu3fdcQoG2WqHQLA/rG6AnNu054CBMiP5JK5EnWRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@percy/cli-command": "1.30.11",
-        "@percy/logger": "1.30.11",
+        "@percy/cli-command": "1.31.2",
+        "@percy/logger": "1.31.2",
         "cross-spawn": "^7.0.3",
         "which": "^2.0.2"
       },
@@ -173,13 +173,13 @@
       }
     },
     "node_modules/@percy/cli-snapshot": {
-      "version": "1.30.11",
-      "resolved": "https://registry.npmjs.org/@percy/cli-snapshot/-/cli-snapshot-1.30.11.tgz",
-      "integrity": "sha512-wc5quGBLghO3vWO4r0lnqL8DxJYPo13oNlbyeCZFWPiCBtxW/AQyTtzBdS//murcM0aP1Yb2vbkLp1eH742vVQ==",
+      "version": "1.31.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli-snapshot/-/cli-snapshot-1.31.2.tgz",
+      "integrity": "sha512-qOnULZY3i4mWn0DonvUzWfcoibMdDgdIbuqiOTgX1SWMhspA5i1BRq3JCtnYKmTXtp0P/SC0N0MfA4blZYqDVw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@percy/cli-command": "1.30.11",
+        "@percy/cli-command": "1.31.2",
         "yaml": "^2.0.0"
       },
       "engines": {
@@ -187,13 +187,13 @@
       }
     },
     "node_modules/@percy/cli-upload": {
-      "version": "1.30.11",
-      "resolved": "https://registry.npmjs.org/@percy/cli-upload/-/cli-upload-1.30.11.tgz",
-      "integrity": "sha512-97zu5KcNcx6A3hrwCHMdi97Wsvd2qg/QkH86FWtnsDzOxLQUuWiDqyuxNnYuBr02dsOwEvwVxeJl0maCsfPNJw==",
+      "version": "1.31.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli-upload/-/cli-upload-1.31.2.tgz",
+      "integrity": "sha512-PsWLBR54FdBsBp1/xHXb0Eym7EA2W49AzM80bGo27VankLq5G2yUqeW0vP6Kq0GXIlr4YkQf+WprXMmI+D7ybg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@percy/cli-command": "1.30.11",
+        "@percy/cli-command": "1.31.2",
         "fast-glob": "^3.2.11",
         "image-size": "^1.0.0"
       },
@@ -202,14 +202,15 @@
       }
     },
     "node_modules/@percy/client": {
-      "version": "1.30.11",
-      "resolved": "https://registry.npmjs.org/@percy/client/-/client-1.30.11.tgz",
-      "integrity": "sha512-1QJK26ZU40GoeqGgMt3cbRdJy2hhb3N9ReSzlYzEiNaSQQ5ZZcL3SXt3IDUtrR6WsoMvT7Kk+6R0yK/JDa8/LA==",
+      "version": "1.31.2",
+      "resolved": "https://registry.npmjs.org/@percy/client/-/client-1.31.2.tgz",
+      "integrity": "sha512-9RdmDm/t7GQVg4dVGueRo9A11LmHVyl2iDPgNHUpkTmv/xc2GuDco2R6ato8alOSjNnUWQ+B6p54DKB7zvOPLA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@percy/env": "1.30.11",
-        "@percy/logger": "1.30.11",
+        "@percy/config": "1.31.2",
+        "@percy/env": "1.31.2",
+        "@percy/logger": "1.31.2",
         "pac-proxy-agent": "^7.0.2",
         "pako": "^2.1.0"
       },
@@ -218,13 +219,13 @@
       }
     },
     "node_modules/@percy/config": {
-      "version": "1.30.11",
-      "resolved": "https://registry.npmjs.org/@percy/config/-/config-1.30.11.tgz",
-      "integrity": "sha512-DZo4pXz6EHIJIH2Y+lzyjVu2bY8hiS2zBNxtXKmxAEB6EoNGlObFDN29ce7xhb/5Rb3/smqk8bDHU45biZKEVQ==",
+      "version": "1.31.2",
+      "resolved": "https://registry.npmjs.org/@percy/config/-/config-1.31.2.tgz",
+      "integrity": "sha512-OCfE6RiI7tANcdByUcRL3M1nR/YYtGhGxtNxdmdMHIMkNUrhiy0F7wvvjrhptI1ihPmrTv9YQ1C/R6vKio6tOg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@percy/logger": "1.30.11",
+        "@percy/logger": "1.31.2",
         "ajv": "^8.6.2",
         "cosmiconfig": "^8.0.0",
         "yaml": "^2.0.0"
@@ -234,19 +235,19 @@
       }
     },
     "node_modules/@percy/core": {
-      "version": "1.30.11",
-      "resolved": "https://registry.npmjs.org/@percy/core/-/core-1.30.11.tgz",
-      "integrity": "sha512-1GSnvQZQ/uzQ4Jp0eZMrUEn+wKyMBE1yi3djZp24zwy5PEGJgm01Wsq409SMwE+J8JGJjCOhshxtfH5UmL7txw==",
+      "version": "1.31.2",
+      "resolved": "https://registry.npmjs.org/@percy/core/-/core-1.31.2.tgz",
+      "integrity": "sha512-3p1q+6DYvjQFFqchpfIHJICSOMeaeSfJlqhQao3u6d4lRdcg4OEiPpFHDTx5VVBH3tRW4SVbnRoKCRJQY5Uptg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@percy/client": "1.30.11",
-        "@percy/config": "1.30.11",
-        "@percy/dom": "1.30.11",
-        "@percy/logger": "1.30.11",
-        "@percy/monitoring": "1.30.11",
-        "@percy/webdriver-utils": "1.30.11",
+        "@percy/client": "1.31.2",
+        "@percy/config": "1.31.2",
+        "@percy/dom": "1.31.2",
+        "@percy/logger": "1.31.2",
+        "@percy/monitoring": "1.31.2",
+        "@percy/webdriver-utils": "1.31.2",
         "content-disposition": "^0.5.4",
         "cross-spawn": "^7.0.3",
         "extract-zip": "^2.0.1",
@@ -264,29 +265,29 @@
       }
     },
     "node_modules/@percy/dom": {
-      "version": "1.30.11",
-      "resolved": "https://registry.npmjs.org/@percy/dom/-/dom-1.30.11.tgz",
-      "integrity": "sha512-g5/28YhKzgU8UWpWHBX1/RXaOjqnoCPl597dTG0s5gJrEuj7teWvkkRMcDhWE4YVfJMT+zXIaxdR0IECaw57iw==",
+      "version": "1.31.2",
+      "resolved": "https://registry.npmjs.org/@percy/dom/-/dom-1.31.2.tgz",
+      "integrity": "sha512-fTlJjWLDq+mBrWcGtxujcwtpSAMZDyehEYCFXrQRxIy1fJDyxbkggOa+2ZfNHiykkV+eAavq+vcS2OYZjdxQOA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@percy/env": {
-      "version": "1.30.11",
-      "resolved": "https://registry.npmjs.org/@percy/env/-/env-1.30.11.tgz",
-      "integrity": "sha512-dOn+yDHvw85SyDkYoJZsceB+/kby+ESqQ2weC6SyM0T5nJQiLVxdgaetJ76DNNW9TmzJMlGPIo1/2BGB9bDe7Q==",
+      "version": "1.31.2",
+      "resolved": "https://registry.npmjs.org/@percy/env/-/env-1.31.2.tgz",
+      "integrity": "sha512-sWebs0Ul/ZN96GOfXVCOxwXh+cbIrSWbdPsDRI0sffz/rvvFPawbaurlw52p722C/pa9vQp/b8tfryo5pldAeQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@percy/logger": "1.30.11"
+        "@percy/logger": "1.31.2"
       },
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@percy/logger": {
-      "version": "1.30.11",
-      "resolved": "https://registry.npmjs.org/@percy/logger/-/logger-1.30.11.tgz",
-      "integrity": "sha512-w1hVsHHpISGNvohmvbRR2oK3RIIGBNhKe04sHo684NK1185B9HrKfPTo/EttRf1hw8cFKlEVCP5Nq+d+ykbCxQ==",
+      "version": "1.31.2",
+      "resolved": "https://registry.npmjs.org/@percy/logger/-/logger-1.31.2.tgz",
+      "integrity": "sha512-PcN0cZZv9+bbdVfi0jlyZY5L+RpYTr0qgkApgf+1yjJurHSZjby2nitIZItGFR2fg7DGf4j/GhlDSdujEGqdjQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -294,15 +295,15 @@
       }
     },
     "node_modules/@percy/monitoring": {
-      "version": "1.30.11",
-      "resolved": "https://registry.npmjs.org/@percy/monitoring/-/monitoring-1.30.11.tgz",
-      "integrity": "sha512-xsUE2ZPdpBJT73P6FlruAgPd/VgzVfmo6gcqiY4UbUeDHtXKIZ7tgYjhYivfeTxI12G03HFQMxRxR0HFiwUrTw==",
+      "version": "1.31.2",
+      "resolved": "https://registry.npmjs.org/@percy/monitoring/-/monitoring-1.31.2.tgz",
+      "integrity": "sha512-42p1gYvx+ymLypp1DjbVK6mqnIGhG0WTOgM6uSDZdx6AbrLR0kEh2CnwxZ0b1v9+xIpYC7ex3/7vnsqSC3GAmg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@percy/config": "1.30.11",
-        "@percy/logger": "1.30.11",
-        "@percy/sdk-utils": "1.30.11",
+        "@percy/config": "1.31.2",
+        "@percy/logger": "1.31.2",
+        "@percy/sdk-utils": "1.31.2",
         "systeminformation": "^5.25.11"
       },
       "engines": {
@@ -310,9 +311,9 @@
       }
     },
     "node_modules/@percy/sdk-utils": {
-      "version": "1.30.11",
-      "resolved": "https://registry.npmjs.org/@percy/sdk-utils/-/sdk-utils-1.30.11.tgz",
-      "integrity": "sha512-EuJB8R+ZS7Q/LpdiCoXM+MIGuBVDtvH0vIYQRK6abu0QlD11ra30eN4beD3zTOIe15CgOawzGFLs3cv1noX5fg==",
+      "version": "1.31.2",
+      "resolved": "https://registry.npmjs.org/@percy/sdk-utils/-/sdk-utils-1.31.2.tgz",
+      "integrity": "sha512-0FRe1rn/Lo5omkfuKJep4VJI9HkQeNriahm3WWAYLvyUvdPL0cgnmqZD6oMyptiCZYgIDZ4n2FSybixoGiozVw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -320,14 +321,14 @@
       }
     },
     "node_modules/@percy/webdriver-utils": {
-      "version": "1.30.11",
-      "resolved": "https://registry.npmjs.org/@percy/webdriver-utils/-/webdriver-utils-1.30.11.tgz",
-      "integrity": "sha512-djIShfhPVms/TE0GLLtM6qY/yz5OSL6ZQS95FqGq1akC/Ti+MXuBF8dws14B4w6CzZiw4gHaVe4IvBrq/y2TJQ==",
+      "version": "1.31.2",
+      "resolved": "https://registry.npmjs.org/@percy/webdriver-utils/-/webdriver-utils-1.31.2.tgz",
+      "integrity": "sha512-V1IZGse/YNROZwH37VsdZT5XW6+QEniNp5HKe+219HzXwl5KNyZpHOHmOXyhTjqPGLcaelrHUtrpleDIVcSlgw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@percy/config": "1.30.11",
-        "@percy/sdk-utils": "1.30.11"
+        "@percy/config": "1.31.2",
+        "@percy/sdk-utils": "1.31.2"
       },
       "engines": {
         "node": ">=14"
@@ -341,14 +342,14 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.15.29",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.29.tgz",
-      "integrity": "sha512-LNdjOkUDlU1RZb8e1kOIUpN1qQUlzGkEtbVNo53vbrwDg5om6oduhm4SiUaPW5ASTXhAiP0jInWG8Qx9fVlOeQ==",
+      "version": "24.7.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.7.1.tgz",
+      "integrity": "sha512-CmyhGZanP88uuC5GpWU9q+fI61j2SkhO3UGMUdfYRE6Bcy0ccyzn1Rqj9YAB/ZY4kOXmNf0ocah5GtphmLMP6Q==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.14.0"
       }
     },
     "node_modules/@types/yauzl": {
@@ -363,9 +364,9 @@
       }
     },
     "node_modules/agent-base": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
-      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -427,9 +428,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -543,9 +544,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -576,9 +577,9 @@
       }
     },
     "node_modules/end-of-stream": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
-      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -586,9 +587,9 @@
       }
     },
     "node_modules/error-ex": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -697,9 +698,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
-      "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
       "dev": true,
       "funding": [
         {
@@ -770,9 +771,9 @@
       }
     },
     "node_modules/get-uri": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.4.tgz",
-      "integrity": "sha512-E1b1lFFLvLgak2whF2xDBcOy6NLVGZBqqjJjsIhvopKfWWEi64pLVTWWehV8KlLerZkfNTA95sTe2OdJKm1OzQ==",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
+      "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -900,15 +901,11 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
-      "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
+      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "jsbn": "1.1.0",
-        "sprintf-js": "^1.1.3"
-      },
       "engines": {
         "node": ">= 12"
       }
@@ -979,13 +976,6 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
-    },
-    "node_modules/jsbn": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
-      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
@@ -1233,9 +1223,9 @@
       }
     },
     "node_modules/pump": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.2.tgz",
-      "integrity": "sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
+      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1402,13 +1392,13 @@
       }
     },
     "node_modules/socks": {
-      "version": "2.8.4",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.4.tgz",
-      "integrity": "sha512-D3YaD0aRxR3mEcqnidIs7ReYJFVzWdd6fXJYUM8ixcQcJRGTka/b3saV0KflYhyVJXKhb947GndU35SxYNResQ==",
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
+      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ip-address": "^9.0.5",
+        "ip-address": "^10.0.1",
         "smart-buffer": "^4.2.0"
       },
       "engines": {
@@ -1442,17 +1432,10 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/sprintf-js": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
-      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
     "node_modules/systeminformation": {
-      "version": "5.27.1",
-      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.27.1.tgz",
-      "integrity": "sha512-FgkVpT6GgATtNvADgtEzDxI/SVaBisfnQ4fmgQZhCJ4335noTgt9q6O81ioHwzs9HgnJaaFSdHSEMIkneZ55iA==",
+      "version": "5.27.11",
+      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.27.11.tgz",
+      "integrity": "sha512-K3Lto/2m3K2twmKHdgx5B+0in9qhXK4YnoT9rIlgwN/4v7OV5c8IjbeAUkuky/6VzCQC7iKCAqi8rZathCdjHg==",
       "dev": true,
       "license": "MIT",
       "os": [
@@ -1490,9 +1473,13 @@
       }
     },
     "node_modules/todomvc-app-css": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/todomvc-app-css/-/todomvc-app-css-2.3.0.tgz",
-      "integrity": "sha512-RG8hxqoVn8Be3wxyuyHfOSAXiY1Z0N+PYQOe/jxzy3wpU1Obfwd1RF1i/fz/fR+MrYL+Q+BdrUt8SsXdtR7Oow=="
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/todomvc-app-css/-/todomvc-app-css-2.4.3.tgz",
+      "integrity": "sha512-mSnWZaKBWj9aQcFRsGguY/a8O8NR8GmecD48yU1rzwNemgZa/INLpIsxxMiToFGVth+uEKBrQ7IhWkaXZxwq5Q==",
+      "license": "CC-BY-4.0",
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/tslib": {
       "version": "2.8.1",
@@ -1502,9 +1489,9 @@
       "license": "0BSD"
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.14.0.tgz",
+      "integrity": "sha512-QQiYxHuyZ9gQUIrmPo3IA+hUl4KYk8uSA7cHrcKd/l3p1OTpZcM0Tbp9x7FAtXdAYhlasd60ncPpgu6ihG6TOA==",
       "dev": true,
       "license": "MIT",
       "optional": true
@@ -1533,9 +1520,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.18.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.2.tgz",
-      "integrity": "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==",
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1555,9 +1542,9 @@
       }
     },
     "node_modules/yaml": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
-      "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
+      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -1624,130 +1611,131 @@
       }
     },
     "@percy/cli": {
-      "version": "1.30.11",
-      "resolved": "https://registry.npmjs.org/@percy/cli/-/cli-1.30.11.tgz",
-      "integrity": "sha512-+UX5w5m3CT7g6OrcYL6WTOTL81dYOG14RxgAuvu8i+6ua2smSN2VfMF8ibHsD+BE/CkHXyqymvosyedWcsVZJw==",
+      "version": "1.31.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli/-/cli-1.31.2.tgz",
+      "integrity": "sha512-/jwlEMuVw0+9fkhUqc8m7s6WU8iZDeOffqVsg0Z2pfznFPvtH3IZtCWqqQan9JjQnx3UbidQPDb50UJ8Xn/AuQ==",
       "dev": true,
       "requires": {
-        "@percy/cli-app": "1.30.11",
-        "@percy/cli-build": "1.30.11",
-        "@percy/cli-command": "1.30.11",
-        "@percy/cli-config": "1.30.11",
-        "@percy/cli-exec": "1.30.11",
-        "@percy/cli-snapshot": "1.30.11",
-        "@percy/cli-upload": "1.30.11",
-        "@percy/client": "1.30.11",
-        "@percy/logger": "1.30.11"
+        "@percy/cli-app": "1.31.2",
+        "@percy/cli-build": "1.31.2",
+        "@percy/cli-command": "1.31.2",
+        "@percy/cli-config": "1.31.2",
+        "@percy/cli-exec": "1.31.2",
+        "@percy/cli-snapshot": "1.31.2",
+        "@percy/cli-upload": "1.31.2",
+        "@percy/client": "1.31.2",
+        "@percy/logger": "1.31.2"
       }
     },
     "@percy/cli-app": {
-      "version": "1.30.11",
-      "resolved": "https://registry.npmjs.org/@percy/cli-app/-/cli-app-1.30.11.tgz",
-      "integrity": "sha512-Iq3QGaDsKWEKIIRQzq09OxuwSFhV2JtGT9poZ9RvDaFrKcy3e3VkHWNH/jcxSv0IPNB6EptEfoG8XVY93OKA8Q==",
+      "version": "1.31.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli-app/-/cli-app-1.31.2.tgz",
+      "integrity": "sha512-juAi7R1ulaMtVLlG//duiEFPo/Aj60ePtEGXCqK5BWboXxJ2Sf6qkfvGo5Tb/GfHziHK7+MQ6GK5yRNaL21k8A==",
       "dev": true,
       "requires": {
-        "@percy/cli-command": "1.30.11",
-        "@percy/cli-exec": "1.30.11"
+        "@percy/cli-command": "1.31.2",
+        "@percy/cli-exec": "1.31.2"
       }
     },
     "@percy/cli-build": {
-      "version": "1.30.11",
-      "resolved": "https://registry.npmjs.org/@percy/cli-build/-/cli-build-1.30.11.tgz",
-      "integrity": "sha512-o0qyiW+F3xX+X/pnKgSgK4Dvc1PKqWHvceanWOw0t1F8Qdq5n/rYOHwkpYKV+jOE4vEH1tpdcRo8YsXq9C+0ug==",
+      "version": "1.31.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli-build/-/cli-build-1.31.2.tgz",
+      "integrity": "sha512-/sRVbIhHaoZWcSAd3ZV31EpJ2A/xBSSmKMoj+aHxKhB+KcSgs8622RdKk4SBzQj/GdOIZjoDxD2XsMtnDgbBuA==",
       "dev": true,
       "requires": {
-        "@percy/cli-command": "1.30.11"
+        "@percy/cli-command": "1.31.2"
       }
     },
     "@percy/cli-command": {
-      "version": "1.30.11",
-      "resolved": "https://registry.npmjs.org/@percy/cli-command/-/cli-command-1.30.11.tgz",
-      "integrity": "sha512-UIkk3IGI5Tazhy6Kho+M04oG9ZFfpyqDuCFGHYNm5ZUPgZcGK0BUrEd9/JmjLPA9AIMSlFn2PGzWSzNDT1+ThQ==",
+      "version": "1.31.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli-command/-/cli-command-1.31.2.tgz",
+      "integrity": "sha512-9baEK7VDU02WUQKcH7M/hohiDlIH7DUEC1kdk7MED+z5hnKWO9DkgcbMpmNbGUTiKb+uPY7nt6h8nNI9kWJMxw==",
       "dev": true,
       "requires": {
-        "@percy/config": "1.30.11",
-        "@percy/core": "1.30.11",
-        "@percy/logger": "1.30.11"
+        "@percy/config": "1.31.2",
+        "@percy/core": "1.31.2",
+        "@percy/logger": "1.31.2"
       }
     },
     "@percy/cli-config": {
-      "version": "1.30.11",
-      "resolved": "https://registry.npmjs.org/@percy/cli-config/-/cli-config-1.30.11.tgz",
-      "integrity": "sha512-R42o/XI1x44vUe4BYlpNrKioc+8PxrC554GcnKmgSWENRnT8e1dZKl3jb5ppKd0qUPBnqDEJCGvpzAVVeiTNuQ==",
+      "version": "1.31.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli-config/-/cli-config-1.31.2.tgz",
+      "integrity": "sha512-9yCOj6LtPd9/E4y9SkhM9IWUdkr2uIchVNXTlTPZizQkuyT2gyolN0y0dddrR4TpmG/K+pLXOQDqRRNTpdY0gg==",
       "dev": true,
       "requires": {
-        "@percy/cli-command": "1.30.11"
+        "@percy/cli-command": "1.31.2"
       }
     },
     "@percy/cli-exec": {
-      "version": "1.30.11",
-      "resolved": "https://registry.npmjs.org/@percy/cli-exec/-/cli-exec-1.30.11.tgz",
-      "integrity": "sha512-UqRx7NaGTtuWhr/Ucq4PCKnJ5V6dTgi5hDZdSWwBhpqHmhdKGD3JFZVCC9xXAO84M7n6VbWOnIDpv+AVe/XWeg==",
+      "version": "1.31.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli-exec/-/cli-exec-1.31.2.tgz",
+      "integrity": "sha512-IuO/+kFLSKJmPG3R66V4Lp5V4f7O/6wjnWc4X/71OFcywVu3fdcQoG2WqHQLA/rG6AnNu054CBMiP5JK5EnWRg==",
       "dev": true,
       "requires": {
-        "@percy/cli-command": "1.30.11",
-        "@percy/logger": "1.30.11",
+        "@percy/cli-command": "1.31.2",
+        "@percy/logger": "1.31.2",
         "cross-spawn": "^7.0.3",
         "which": "^2.0.2"
       }
     },
     "@percy/cli-snapshot": {
-      "version": "1.30.11",
-      "resolved": "https://registry.npmjs.org/@percy/cli-snapshot/-/cli-snapshot-1.30.11.tgz",
-      "integrity": "sha512-wc5quGBLghO3vWO4r0lnqL8DxJYPo13oNlbyeCZFWPiCBtxW/AQyTtzBdS//murcM0aP1Yb2vbkLp1eH742vVQ==",
+      "version": "1.31.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli-snapshot/-/cli-snapshot-1.31.2.tgz",
+      "integrity": "sha512-qOnULZY3i4mWn0DonvUzWfcoibMdDgdIbuqiOTgX1SWMhspA5i1BRq3JCtnYKmTXtp0P/SC0N0MfA4blZYqDVw==",
       "dev": true,
       "requires": {
-        "@percy/cli-command": "1.30.11",
+        "@percy/cli-command": "1.31.2",
         "yaml": "^2.0.0"
       }
     },
     "@percy/cli-upload": {
-      "version": "1.30.11",
-      "resolved": "https://registry.npmjs.org/@percy/cli-upload/-/cli-upload-1.30.11.tgz",
-      "integrity": "sha512-97zu5KcNcx6A3hrwCHMdi97Wsvd2qg/QkH86FWtnsDzOxLQUuWiDqyuxNnYuBr02dsOwEvwVxeJl0maCsfPNJw==",
+      "version": "1.31.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli-upload/-/cli-upload-1.31.2.tgz",
+      "integrity": "sha512-PsWLBR54FdBsBp1/xHXb0Eym7EA2W49AzM80bGo27VankLq5G2yUqeW0vP6Kq0GXIlr4YkQf+WprXMmI+D7ybg==",
       "dev": true,
       "requires": {
-        "@percy/cli-command": "1.30.11",
+        "@percy/cli-command": "1.31.2",
         "fast-glob": "^3.2.11",
         "image-size": "^1.0.0"
       }
     },
     "@percy/client": {
-      "version": "1.30.11",
-      "resolved": "https://registry.npmjs.org/@percy/client/-/client-1.30.11.tgz",
-      "integrity": "sha512-1QJK26ZU40GoeqGgMt3cbRdJy2hhb3N9ReSzlYzEiNaSQQ5ZZcL3SXt3IDUtrR6WsoMvT7Kk+6R0yK/JDa8/LA==",
+      "version": "1.31.2",
+      "resolved": "https://registry.npmjs.org/@percy/client/-/client-1.31.2.tgz",
+      "integrity": "sha512-9RdmDm/t7GQVg4dVGueRo9A11LmHVyl2iDPgNHUpkTmv/xc2GuDco2R6ato8alOSjNnUWQ+B6p54DKB7zvOPLA==",
       "dev": true,
       "requires": {
-        "@percy/env": "1.30.11",
-        "@percy/logger": "1.30.11",
+        "@percy/config": "1.31.2",
+        "@percy/env": "1.31.2",
+        "@percy/logger": "1.31.2",
         "pac-proxy-agent": "^7.0.2",
         "pako": "^2.1.0"
       }
     },
     "@percy/config": {
-      "version": "1.30.11",
-      "resolved": "https://registry.npmjs.org/@percy/config/-/config-1.30.11.tgz",
-      "integrity": "sha512-DZo4pXz6EHIJIH2Y+lzyjVu2bY8hiS2zBNxtXKmxAEB6EoNGlObFDN29ce7xhb/5Rb3/smqk8bDHU45biZKEVQ==",
+      "version": "1.31.2",
+      "resolved": "https://registry.npmjs.org/@percy/config/-/config-1.31.2.tgz",
+      "integrity": "sha512-OCfE6RiI7tANcdByUcRL3M1nR/YYtGhGxtNxdmdMHIMkNUrhiy0F7wvvjrhptI1ihPmrTv9YQ1C/R6vKio6tOg==",
       "dev": true,
       "requires": {
-        "@percy/logger": "1.30.11",
+        "@percy/logger": "1.31.2",
         "ajv": "^8.6.2",
         "cosmiconfig": "^8.0.0",
         "yaml": "^2.0.0"
       }
     },
     "@percy/core": {
-      "version": "1.30.11",
-      "resolved": "https://registry.npmjs.org/@percy/core/-/core-1.30.11.tgz",
-      "integrity": "sha512-1GSnvQZQ/uzQ4Jp0eZMrUEn+wKyMBE1yi3djZp24zwy5PEGJgm01Wsq409SMwE+J8JGJjCOhshxtfH5UmL7txw==",
+      "version": "1.31.2",
+      "resolved": "https://registry.npmjs.org/@percy/core/-/core-1.31.2.tgz",
+      "integrity": "sha512-3p1q+6DYvjQFFqchpfIHJICSOMeaeSfJlqhQao3u6d4lRdcg4OEiPpFHDTx5VVBH3tRW4SVbnRoKCRJQY5Uptg==",
       "dev": true,
       "requires": {
-        "@percy/client": "1.30.11",
-        "@percy/config": "1.30.11",
-        "@percy/dom": "1.30.11",
-        "@percy/logger": "1.30.11",
-        "@percy/monitoring": "1.30.11",
-        "@percy/webdriver-utils": "1.30.11",
+        "@percy/client": "1.31.2",
+        "@percy/config": "1.31.2",
+        "@percy/dom": "1.31.2",
+        "@percy/logger": "1.31.2",
+        "@percy/monitoring": "1.31.2",
+        "@percy/webdriver-utils": "1.31.2",
         "content-disposition": "^0.5.4",
         "cross-spawn": "^7.0.3",
         "extract-zip": "^2.0.1",
@@ -1762,52 +1750,52 @@
       }
     },
     "@percy/dom": {
-      "version": "1.30.11",
-      "resolved": "https://registry.npmjs.org/@percy/dom/-/dom-1.30.11.tgz",
-      "integrity": "sha512-g5/28YhKzgU8UWpWHBX1/RXaOjqnoCPl597dTG0s5gJrEuj7teWvkkRMcDhWE4YVfJMT+zXIaxdR0IECaw57iw==",
+      "version": "1.31.2",
+      "resolved": "https://registry.npmjs.org/@percy/dom/-/dom-1.31.2.tgz",
+      "integrity": "sha512-fTlJjWLDq+mBrWcGtxujcwtpSAMZDyehEYCFXrQRxIy1fJDyxbkggOa+2ZfNHiykkV+eAavq+vcS2OYZjdxQOA==",
       "dev": true
     },
     "@percy/env": {
-      "version": "1.30.11",
-      "resolved": "https://registry.npmjs.org/@percy/env/-/env-1.30.11.tgz",
-      "integrity": "sha512-dOn+yDHvw85SyDkYoJZsceB+/kby+ESqQ2weC6SyM0T5nJQiLVxdgaetJ76DNNW9TmzJMlGPIo1/2BGB9bDe7Q==",
+      "version": "1.31.2",
+      "resolved": "https://registry.npmjs.org/@percy/env/-/env-1.31.2.tgz",
+      "integrity": "sha512-sWebs0Ul/ZN96GOfXVCOxwXh+cbIrSWbdPsDRI0sffz/rvvFPawbaurlw52p722C/pa9vQp/b8tfryo5pldAeQ==",
       "dev": true,
       "requires": {
-        "@percy/logger": "1.30.11"
+        "@percy/logger": "1.31.2"
       }
     },
     "@percy/logger": {
-      "version": "1.30.11",
-      "resolved": "https://registry.npmjs.org/@percy/logger/-/logger-1.30.11.tgz",
-      "integrity": "sha512-w1hVsHHpISGNvohmvbRR2oK3RIIGBNhKe04sHo684NK1185B9HrKfPTo/EttRf1hw8cFKlEVCP5Nq+d+ykbCxQ==",
+      "version": "1.31.2",
+      "resolved": "https://registry.npmjs.org/@percy/logger/-/logger-1.31.2.tgz",
+      "integrity": "sha512-PcN0cZZv9+bbdVfi0jlyZY5L+RpYTr0qgkApgf+1yjJurHSZjby2nitIZItGFR2fg7DGf4j/GhlDSdujEGqdjQ==",
       "dev": true
     },
     "@percy/monitoring": {
-      "version": "1.30.11",
-      "resolved": "https://registry.npmjs.org/@percy/monitoring/-/monitoring-1.30.11.tgz",
-      "integrity": "sha512-xsUE2ZPdpBJT73P6FlruAgPd/VgzVfmo6gcqiY4UbUeDHtXKIZ7tgYjhYivfeTxI12G03HFQMxRxR0HFiwUrTw==",
+      "version": "1.31.2",
+      "resolved": "https://registry.npmjs.org/@percy/monitoring/-/monitoring-1.31.2.tgz",
+      "integrity": "sha512-42p1gYvx+ymLypp1DjbVK6mqnIGhG0WTOgM6uSDZdx6AbrLR0kEh2CnwxZ0b1v9+xIpYC7ex3/7vnsqSC3GAmg==",
       "dev": true,
       "requires": {
-        "@percy/config": "1.30.11",
-        "@percy/logger": "1.30.11",
-        "@percy/sdk-utils": "1.30.11",
+        "@percy/config": "1.31.2",
+        "@percy/logger": "1.31.2",
+        "@percy/sdk-utils": "1.31.2",
         "systeminformation": "^5.25.11"
       }
     },
     "@percy/sdk-utils": {
-      "version": "1.30.11",
-      "resolved": "https://registry.npmjs.org/@percy/sdk-utils/-/sdk-utils-1.30.11.tgz",
-      "integrity": "sha512-EuJB8R+ZS7Q/LpdiCoXM+MIGuBVDtvH0vIYQRK6abu0QlD11ra30eN4beD3zTOIe15CgOawzGFLs3cv1noX5fg==",
+      "version": "1.31.2",
+      "resolved": "https://registry.npmjs.org/@percy/sdk-utils/-/sdk-utils-1.31.2.tgz",
+      "integrity": "sha512-0FRe1rn/Lo5omkfuKJep4VJI9HkQeNriahm3WWAYLvyUvdPL0cgnmqZD6oMyptiCZYgIDZ4n2FSybixoGiozVw==",
       "dev": true
     },
     "@percy/webdriver-utils": {
-      "version": "1.30.11",
-      "resolved": "https://registry.npmjs.org/@percy/webdriver-utils/-/webdriver-utils-1.30.11.tgz",
-      "integrity": "sha512-djIShfhPVms/TE0GLLtM6qY/yz5OSL6ZQS95FqGq1akC/Ti+MXuBF8dws14B4w6CzZiw4gHaVe4IvBrq/y2TJQ==",
+      "version": "1.31.2",
+      "resolved": "https://registry.npmjs.org/@percy/webdriver-utils/-/webdriver-utils-1.31.2.tgz",
+      "integrity": "sha512-V1IZGse/YNROZwH37VsdZT5XW6+QEniNp5HKe+219HzXwl5KNyZpHOHmOXyhTjqPGLcaelrHUtrpleDIVcSlgw==",
       "dev": true,
       "requires": {
-        "@percy/config": "1.30.11",
-        "@percy/sdk-utils": "1.30.11"
+        "@percy/config": "1.31.2",
+        "@percy/sdk-utils": "1.31.2"
       }
     },
     "@tootallnate/quickjs-emscripten": {
@@ -1817,13 +1805,13 @@
       "dev": true
     },
     "@types/node": {
-      "version": "22.15.29",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.29.tgz",
-      "integrity": "sha512-LNdjOkUDlU1RZb8e1kOIUpN1qQUlzGkEtbVNo53vbrwDg5om6oduhm4SiUaPW5ASTXhAiP0jInWG8Qx9fVlOeQ==",
+      "version": "24.7.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.7.1.tgz",
+      "integrity": "sha512-CmyhGZanP88uuC5GpWU9q+fI61j2SkhO3UGMUdfYRE6Bcy0ccyzn1Rqj9YAB/ZY4kOXmNf0ocah5GtphmLMP6Q==",
       "dev": true,
       "optional": true,
       "requires": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.14.0"
       }
     },
     "@types/yauzl": {
@@ -1837,9 +1825,9 @@
       }
     },
     "agent-base": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
-      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
       "dev": true
     },
     "ajv": {
@@ -1882,9 +1870,9 @@
       "dev": true
     },
     "brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
@@ -1957,9 +1945,9 @@
       "dev": true
     },
     "debug": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
       "requires": {
         "ms": "^2.1.3"
@@ -1977,18 +1965,18 @@
       }
     },
     "end-of-stream": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
-      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
       "dev": true,
       "requires": {
         "once": "^1.4.0"
       }
     },
     "error-ex": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
       "dev": true,
       "requires": {
         "is-arrayish": "^0.2.1"
@@ -2056,9 +2044,9 @@
       }
     },
     "fast-uri": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
-      "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
       "dev": true
     },
     "fastq": {
@@ -2104,9 +2092,9 @@
       }
     },
     "get-uri": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.4.tgz",
-      "integrity": "sha512-E1b1lFFLvLgak2whF2xDBcOy6NLVGZBqqjJjsIhvopKfWWEi64pLVTWWehV8KlLerZkfNTA95sTe2OdJKm1OzQ==",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
+      "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
       "dev": true,
       "requires": {
         "basic-ftp": "^5.0.2",
@@ -2193,14 +2181,10 @@
       "dev": true
     },
     "ip-address": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
-      "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
-      "dev": true,
-      "requires": {
-        "jsbn": "1.1.0",
-        "sprintf-js": "^1.1.3"
-      }
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
+      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "dev": true
     },
     "is-arrayish": {
       "version": "0.2.1",
@@ -2249,12 +2233,6 @@
       "requires": {
         "argparse": "^2.0.1"
       }
-    },
-    "jsbn": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
-      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
-      "dev": true
     },
     "json-parse-even-better-errors": {
       "version": "2.3.1",
@@ -2431,9 +2409,9 @@
       "dev": true
     },
     "pump": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.2.tgz",
-      "integrity": "sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
+      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
       "dev": true,
       "requires": {
         "end-of-stream": "^1.1.0",
@@ -2519,12 +2497,12 @@
       "dev": true
     },
     "socks": {
-      "version": "2.8.4",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.4.tgz",
-      "integrity": "sha512-D3YaD0aRxR3mEcqnidIs7ReYJFVzWdd6fXJYUM8ixcQcJRGTka/b3saV0KflYhyVJXKhb947GndU35SxYNResQ==",
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
+      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
       "dev": true,
       "requires": {
-        "ip-address": "^9.0.5",
+        "ip-address": "^10.0.1",
         "smart-buffer": "^4.2.0"
       }
     },
@@ -2546,16 +2524,10 @@
       "dev": true,
       "optional": true
     },
-    "sprintf-js": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
-      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
-      "dev": true
-    },
     "systeminformation": {
-      "version": "5.27.1",
-      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.27.1.tgz",
-      "integrity": "sha512-FgkVpT6GgATtNvADgtEzDxI/SVaBisfnQ4fmgQZhCJ4335noTgt9q6O81ioHwzs9HgnJaaFSdHSEMIkneZ55iA==",
+      "version": "5.27.11",
+      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.27.11.tgz",
+      "integrity": "sha512-K3Lto/2m3K2twmKHdgx5B+0in9qhXK4YnoT9rIlgwN/4v7OV5c8IjbeAUkuky/6VzCQC7iKCAqi8rZathCdjHg==",
       "dev": true
     },
     "to-regex-range": {
@@ -2568,9 +2540,9 @@
       }
     },
     "todomvc-app-css": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/todomvc-app-css/-/todomvc-app-css-2.3.0.tgz",
-      "integrity": "sha512-RG8hxqoVn8Be3wxyuyHfOSAXiY1Z0N+PYQOe/jxzy3wpU1Obfwd1RF1i/fz/fR+MrYL+Q+BdrUt8SsXdtR7Oow=="
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/todomvc-app-css/-/todomvc-app-css-2.4.3.tgz",
+      "integrity": "sha512-mSnWZaKBWj9aQcFRsGguY/a8O8NR8GmecD48yU1rzwNemgZa/INLpIsxxMiToFGVth+uEKBrQ7IhWkaXZxwq5Q=="
     },
     "tslib": {
       "version": "2.8.1",
@@ -2579,9 +2551,9 @@
       "dev": true
     },
     "undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.14.0.tgz",
+      "integrity": "sha512-QQiYxHuyZ9gQUIrmPo3IA+hUl4KYk8uSA7cHrcKd/l3p1OTpZcM0Tbp9x7FAtXdAYhlasd60ncPpgu6ihG6TOA==",
       "dev": true,
       "optional": true
     },
@@ -2601,16 +2573,16 @@
       "dev": true
     },
     "ws": {
-      "version": "8.18.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.2.tgz",
-      "integrity": "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==",
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
       "dev": true,
       "requires": {}
     },
     "yaml": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
-      "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
+      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
       "dev": true
     },
     "yauzl": {

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "private": true,
   "dependencies": {
-    "todomvc-app-css": "^2.3.0"
+    "todomvc-app-css": "^2.4.3"
   },
   "devDependencies": {
-    "@percy/cli": "^1.30.11"
+    "@percy/cli": "^1.31.2"
   }
 }

--- a/tests/todo.rb
+++ b/tests/todo.rb
@@ -10,7 +10,7 @@ Thread.new {
 }
 
 options = Selenium::WebDriver::Firefox::Options.new(args: ['--headless'])
-driver = Selenium::WebDriver.for(:firefox, capabilities: [options])
+driver = Selenium::WebDriver.for(:firefox, options: options)
 wait = Selenium::WebDriver::Wait.new(:timeout => 8)
 
 # go to the example app


### PR DESCRIPTION
Changes performed in branch PER_5831

Summary:
- Updated JavaScript and Ruby dependencies to recent versions.
- Fixed tests to be compatible with newer `selenium-webdriver` API.
- Installed missing stdlib gems (`webrick`, `base64`) required for Ruby 3.4+.
- Ran two Percy web builds (builds captured below) to verify snapshots upload successfully.

Files changed:
- `package.json` — bumped `todomvc-app-css` to ^2.4.3 and `@percy/cli` to ^1.31.2
- `Gemfile` — bumped `selenium-webdriver` to ~> 4.36.0; added `webrick` and `base64` gems
- `tests/todo.rb` — updated Selenium driver initialization to use `options:`
- `README.md` — added Versions section reflecting new versions used
- `Gemfile.lock`, `package-lock.json` — updated by package managers

Steps performed:
1. Ran `web-t && make test` to reproduce existing behavior and capture initial errors.
2. Inspected and updated npm and Ruby dependencies (`package.json`, `Gemfile`).
3. Ran `npm install` and `bundle install` / `bundle update` to install updated packages into `node_modules` and `vendor/bundle`.
4. Fixed missing stdlib dependency errors by adding `webrick` and `base64` to `Gemfile`.
5. Updated `tests/todo.rb` to use `Selenium::WebDriver.for(:firefox, options: options)` to match selenium-webdriver 4.36.0 API.
6. Ran Percy web builds twice (below) to ensure snapshots were taken successfully.
7. Created branch `PER_5831`, committed changes, and pushed to origin.

Percy builds created during verification:
- Build 98: https://percy.io/9560f98d/web/test-pranav-8a4f5725/builds/43773647
- Build 99: https://percy.io/9560f98d/web/test-pranav-8a4f5725/builds/43773657

Notes / Rationale:
- `percy-selenium` latest available is 1.1.1; no upgrade needed there.
- Selenium API changed between 4.0.x and 4.36.x; the driver init argument name is now `options:`. Adjusted test accordingly.
- Adding `webrick` and `base64` ensures compatibility with Ruby 3.4+ where these are no longer bundled by default.

How to reproduce locally:
1. Load Percy token with `web-t` in your shell (already present in this environment).
2. Run `make install` to set up node and Ruby dependencies.
3. Run `make test` to execute tests and create Percy snapshots.
